### PR TITLE
Add Job{Started,Finished,Error} events

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,6 +88,21 @@ func (c *ReportingClient) RunStepLogs(ctx context.Context, args RunStepLogsArgs)
 	return c.postJSON("runsteplogs", args)
 }
 
+// JobStarted serializes args and sends them to a remote reporter service.
+func (c *ReportingClient) JobStarted(ctx context.Context, args JobStartedArgs) error {
+	return c.postJSON("jobstarted", args)
+}
+
+// JobError serializes args and sends them to a remote reporter service.
+func (c *ReportingClient) JobError(ctx context.Context, args JobErrorArgs) error {
+	return c.postJSON("joberror", args)
+}
+
+// JobFinished serializes args and sends them to a remote reporter service.
+func (c *ReportingClient) JobFinished(ctx context.Context, args JobFinishedArgs) error {
+	return c.postJSON("jobfinished", args)
+}
+
 func (c *ReportingClient) generateURL(path string) string {
 	return fmt.Sprintf("%s/%s", c.baseURI, path)
 }

--- a/reportingservice.go
+++ b/reportingservice.go
@@ -26,6 +26,10 @@ type ReportingService interface {
 	RunStepStarted(ctx context.Context, args RunStepStartedArgs) error
 	RunStepFinished(ctx context.Context, args RunStepFinishedArgs) error
 	RunStepLogs(ctx context.Context, args RunStepLogsArgs) error
+
+	JobStarted(ctx context.Context, args JobStartedArgs) error
+	JobFinished(ctx context.Context, args JobFinishedArgs) error
+	JobError(ctx context.Context, args JobErrorArgs) error
 }
 
 // RunStartedArgs the arguments asscociated with the RunStarted event.
@@ -83,4 +87,22 @@ type RunStepLogsArgs struct {
 	Logs   []byte `json:"logs"`
 	Stream string `json:"stream"`
 	Chunk  int    `json:"chunk"`
+}
+
+// JobStartedArgs are the arguments that are asscociated with the JobStarted
+// event.
+type JobStartedArgs struct {
+	RunID string `json:"runId"`
+}
+
+// JobFinishedArgs are the arguments that are asscociated with the JobFinished
+// event.
+type JobFinishedArgs struct {
+	RunID string `json:"runId"`
+}
+
+// JobErrorArgs are the arguments that are asscociated with the JobError event.
+type JobErrorArgs struct {
+	RunID string `json:"runId"`
+	Error string `json:"error"`
 }


### PR DESCRIPTION
# Why
This gives us more control on controlling the state of a run.

# What
Add Job{Started,Finished,Error} events